### PR TITLE
Start using logging

### DIFF
--- a/deepaas/api/__init__.py
+++ b/deepaas/api/__init__.py
@@ -16,24 +16,37 @@
 
 import flask
 import flask_restplus
+from oslo_log import log as logging
 
 import deepaas
 from deepaas.api import v1
 from deepaas import model
 
-app = flask.Flask(__name__)
-app.config.SWAGGER_UI_DOC_EXPANSION = 'list'
+LOG = logging.getLogger(__name__)
 
-api = flask_restplus.Api(
-    app,
-    version=deepaas.__version__,
-    title='DEEP as a Service API endpoint',
-    description='DEEP as a Service (DEEPaaS) API endpoint.',
-)
-
-api.add_namespace(v1.api, path="/models")
+APP = None
 
 
 def get_app():
-    print("Loaded models: %s" % model.MODELS.keys())
-    return app
+    global APP
+
+    if APP:
+        return APP
+
+    model.register_models()
+
+    APP = flask.Flask(__name__)
+    APP.config.SWAGGER_UI_DOC_EXPANSION = 'list'
+
+    api = flask_restplus.Api(
+        APP,
+        version=deepaas.__version__,
+        title='DEEP as a Service API endpoint',
+        description='DEEP as a Service (DEEPaaS) API endpoint.',
+    )
+
+    api.add_namespace(v1.api, path="/models")
+
+    LOG.info("Serving loaded models: %s", model.MODELS.keys())
+
+    return APP

--- a/deepaas/cmd/run.py
+++ b/deepaas/cmd/run.py
@@ -18,7 +18,9 @@
 import sys
 
 from oslo_config import cfg
+from oslo_log import log as logging
 
+import deepaas
 from deepaas import api
 from deepaas import config
 
@@ -47,11 +49,16 @@ CONF.register_cli_opts(cli_opts)
 
 def main():
     config.parse_args(sys.argv)
+    logging.setup(CONF, "deepaas")
+    log = logging.getLogger(__name__)
+
+    log.info("Starting DEEPaaS version %s", deepaas.__version__)
+
     app = api.get_app()
     app.run(
-        debug=True,
         host=CONF.listen_ip,
         port=CONF.listen_port,
+        debug=CONF.debug,
     )
 
 

--- a/deepaas/config.py
+++ b/deepaas/config.py
@@ -14,12 +14,23 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import logging
+import warnings
+
 from oslo_config import cfg
+from oslo_log import log
 
 import deepaas
 
+logging.captureWarnings(True)
+warnings.simplefilter("default", DeprecationWarning)
+
 
 def parse_args(argv, default_config_files=None):
+    log.register_options(cfg.CONF)
+
+    log.set_defaults(default_log_levels=log.get_default_log_levels())
+
     cfg.CONF(argv[1:],
              project='deepaas',
              version=deepaas.__version__,

--- a/deepaas/tests/base.py
+++ b/deepaas/tests/base.py
@@ -18,9 +18,13 @@ import os
 
 import fixtures
 from oslo_config import cfg
+from oslo_config import fixture as config_fixture
+from oslo_log import log as logging
 import testtools
 
 CONF = cfg.CONF
+logging.register_options(CONF)
+
 
 _TRUE_VALUES = ('True', 'true', '1', 'yes')
 
@@ -41,6 +45,8 @@ class TestCase(testtools.TestCase):
             test_timeout = 0
         if test_timeout > 0:
             self.useFixture(fixtures.Timeout(test_timeout, gentle=True))
+
+        self.useFixture(config_fixture.Config(CONF))
 
         if os.environ.get('TESTR_STDOUT_CAPTURE') in _TRUE_VALUES:
             stdout = self.useFixture(fixtures.StringStream('stdout')).stream

--- a/deepaas/tests/test_api.py
+++ b/deepaas/tests/test_api.py
@@ -30,7 +30,7 @@ from deepaas.tests import base
 
 
 class TestApi(base.TestCase):
-    @mock.patch('deepaas.api.app')
+    @mock.patch('deepaas.api.APP')
     def test_get_app(self, mock_app):
         self.assertEqual(mock_app, api.get_app())
 
@@ -61,6 +61,8 @@ class TestApiV1(base.TestCase):
 
         api = flask_restplus.Api(app, doc=False)
         api.add_namespace(v1.api)
+
+        deepaas.model.register_models()
 
         self.app = app.test_client()
         self.assertEqual(app.debug, True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # process, which may cause wedges in the gate later.
 pbr>=1.8
 
+oslo.log>=1.8.0 # Apache-2.0
 oslo.config>=2.3.0 # Apache-2.0
 
 enum34


### PR DESCRIPTION
# Description
Instead of using simple print statements, lets start use logging. As a
side effect, some modules where loading plugins when the module was
imported, printing (thus logging) things before the logger was set up.
This change also fixes this, loading things after logging is properly
configured.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
