### PR TITLE
Move Dockerfile to repository's root path.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,11 @@ RUN apt-get install -y --no-install-recommends \
         python3-pip \
         python3-wheel
 
+ADD . /srv
 WORKDIR /srv
 
 # We can use pip or pip3, depending on the python version that we want to use
-RUN git clone https://github.com/indigo-dc/DEEPaaS && \
-    cd deepaas && \
-    pip install .
+RUN pip install .
 
 EXPOSE 5000
 


### PR DESCRIPTION
Additional fix: Do not clone the repo.

# Description

Add Dockerfile to repository's root path to avoid copying repository files when building the image.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

# How Has This Been Tested?

- [x] Local Dockerfile build

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
