### PR TITLE
Add a private api class

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=./deepaas/tests/
+top_dir=./

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,7 +1,0 @@
-[DEFAULT]
-test_command=TESTR_STDOUT_CAPTURE=${TESTR_STDOUT_CAPTURE:-1} \
-             TESTR_STDERR_CAPTURE=${TESTR_STDERR_CAPTURE:-1} \
-             TESTR_TEST_TIMEOUT=${TESTR_TEST_TIMEOUT:-60} \
-             ${PYTHON:-python} -m subunit.run discover -t ./ . $LISTOPT $IDOPTION
-test_id_option=--load-list $IDFILE
-test_list_option=--list

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
 
 [files]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,11 +5,14 @@ hacking<0.10,>=0.9.2
 
 bandit>=1.1.0 # Apache-2.0
 
-coverage>=3.6
+# Remove once we rely on coverage 4.3+
+#
+# https://bitbucket.org/ned/coveragepy/issues/519/
+coverage!=4.4,>=4.0 # Apache-2.0
 
 fixtures>=1.3.1
 python-subunit>=0.0.18
-testrepository>=0.0.18
+stestr>=1.0.0 # Apache-2.0
 testtools>=1.4.0
 
 mock>=1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,68 @@
 [tox]
 minversion = 1.6
-envlist = py36,py34,py27,pep8
+envlist = py{35,36,27},pep8
 skipsdist = True
 
 [testenv]
 usedevelop = True
+basepython = python3
+whitelist_externals =
+  find
 install_command = pip install -U {opts} {packages}
 setenv =
    VIRTUAL_ENV={envdir}
+   LC_ALL=en_US.utf-8
+   OS_STDOUT_CAPTURE=1
+   OS_STDERR_CAPTURE=1
+   OS_TEST_TIMEOUT=160
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = python setup.py testr --slowest --testr-args='{posargs}'
+commands =
+    find . -type f -name "*.pyc" -delete
 
 [testenv:venv]
 commands = {posargs}
 
 [testenv:cover]
-commands = python setup.py testr --coverage --testr-args='{posargs}'
+# TODO(stephenfin): Remove the PYTHON hack below in favour of a [coverage]
+# section once we rely on coverage 4.3+
+#
+# https://bitbucket.org/ned/coveragepy/issues/519/
+envdir = {toxworkdir}/shared
+setenv =
+  {[testenv]setenv}
+  PYTHON=coverage run --source deepaas --parallel-mode
+commands =
+  {[testenv]commands}
+  coverage erase
+  stestr run {posargs}
+  coverage combine
+  coverage html -d cover
+  coverage xml -o cover/coverage.xml
+  coverage report
+
+[testenv:py27]
+# TODO(efried): Remove this once https://github.com/tox-dev/tox/issues/425 is fixed.
+basepython = python2.7
+commands =
+  {[testenv]commands}
+  stestr run {posargs} 
+
+[testenv:py35]
+# TODO(efried): Remove this once https://github.com/tox-dev/tox/issues/425 is fixed.
+basepython = python3.5
+commands =
+  {[testenv]commands}
+  stestr run {posargs}
+
+[testenv:py36]
+# TODO(efried): Remove this once https://github.com/tox-dev/tox/issues/425 is fixed.
+basepython = python3.6
+commands =
+  {[testenv:py35]commands}
 
 [testenv:pep8]
+envdir = {toxworkdir}/shared
 commands =
   flake8
   # Run security linter
@@ -27,8 +71,7 @@ commands =
   bandit -r deepaas -x tests -s B110,B410
 
 [testenv:bandit]
-# NOTE(browne): This is required for the integration test job of the bandit
-# project. Please do not remove.
+envdir = {toxworkdir}/shared
 commands = bandit -r deepaas -x tests -s B110,B410
 
 [flake8]


### PR DESCRIPTION
# Description

Define a base class for all models

Although when using entrypoints it is not mandatory to use classes (any
importable python object can be used, in python everything is an object,
so we can use modules) it is useful to define a class to document the
API that we expect.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
