### PR TITLE
docs: fix document generation on Read the Docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,22 +34,10 @@ sys.path.insert(0, os.path.abspath('./'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 
 extensions = ['sphinx.ext.autodoc',
-#              'sphinx.ext.todo',
-#              'openstackdocstheme',
-#              'sphinx.ext.coverage',
-#              'sphinx.ext.graphviz',
-#              'ext.support_matrix',
               'oslo_config.sphinxconfiggen',
               'oslo_config.sphinxext',
-#              'oslo_policy.sphinxpolicygen',
-#              'oslo_policy.sphinxext',
-#              'ext.versioned_notifications',
-#              'ext.feature_matrix',
-#              'sphinxcontrib.actdiag',
-#              'sphinxcontrib.seqdiag',
-#              'recommonmark'
               "reno.sphinxext",
-              ]
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/configuration/config.rst
+++ b/doc/source/configuration/config.rst
@@ -6,5 +6,9 @@ The following is an overview of all available configuration options in Nova.
 For a sample configuration file, refer to :doc:`/configuration/sample`.
 
 .. show-options::
-   :config-file: etc/deepaas-config-generator.conf
+   deepaas
 
+Logging options
+---------------
+.. show-options::
+   oslo.log

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,4 @@
+requirements_file: test-requirements.txt
+
+python:
+   pip_install: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ classifier =
     Programming Language :: Python :: 3
     Topic :: Internet :: WWW/HTTP
     Topic :: Scientific/Engineering :: Artificial Intelligence
-    Topic :: Scientific/Engineering :: Image Recognition  Copy classifier
-    Topic :: Scientific/Engineering :: Information Analysis  Copy classifier
+    Topic :: Scientific/Engineering :: Image Recognition
+    Topic :: Scientific/Engineering :: Information Analysis
     Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator
 
 [bdist_wheel]


### PR DESCRIPTION
Unfortunately we cannot simply build the docs on rtfd and we need to
configure and change a couple of things.