### PR TITLE
Add support to run DEEPaaS as an OpenWhisk Docker action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="Alvaro Lopez Garcia <aloga@ifca.unican.es>"
-LABEL version="0.1.0"
+LABEL version="0.2.0"
 LABEL description="DEEP as a Service Generic Container"
 
 RUN apt-get update && \
@@ -23,4 +23,4 @@ RUN ansible-playbook -c local -i 'localhost,' /tmp/test.yml
 
 EXPOSE 5000
 
-CMD deepaas-run
+CMD ["sh", "-c", "deepaas-run --openwhisk --listen-ip 0.0.0.0"]

--- a/deepaas/api/__init__.py
+++ b/deepaas/api/__init__.py
@@ -27,7 +27,11 @@ LOG = logging.getLogger(__name__)
 APP = None
 
 
-def get_app():
+def get_app(doc="/"):
+    """Get the Flask-RESTPlus app.
+
+    Set doc to False if you do not want to get the Swagger documentation.
+    """
     global APP
 
     if APP:
@@ -38,11 +42,13 @@ def get_app():
     APP = flask.Flask(__name__)
     APP.config.SWAGGER_UI_DOC_EXPANSION = 'list'
 
+    print(doc)
     api = flask_restplus.Api(
         APP,
         version=deepaas.__version__,
         title='DEEP as a Service API endpoint',
         description='DEEP as a Service (DEEPaaS) API endpoint.',
+        doc=doc
     )
 
     api.add_namespace(v1.api, path="/models")

--- a/deepaas/cmd/wsk.py
+++ b/deepaas/cmd/wsk.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 Spanish National Research Council (CSIC)
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import sys
+
+from oslo_config import cfg
+from oslo_log import log as logging
+
+import deepaas
+from deepaas import config
+from deepaas.openwisk import proxy
+
+cli_opts = [
+    cfg.StrOpt('listen-ip',
+               default='127.0.0.1',
+               help="""
+IP address on which the DEEPaaS API will listen.
+
+The DEEPaaS API service listens on this IP address for incoming
+requests.
+"""),
+]
+
+CONF = cfg.CONF
+CONF.register_cli_opts(cli_opts)
+
+
+def main():
+    config.parse_args(sys.argv)
+    logging.setup(CONF, "deepaas")
+    log = logging.getLogger(__name__)
+
+    log.info("Starting DEEPaaS (OpenWhisk) version %s", deepaas.__version__)
+
+    proxy.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/deepaas/openwisk/handle.py
+++ b/deepaas/openwisk/handle.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+# Copyright Alex Milowski
+# Copyright 2018 Spanish National Research Council (CSIC)
+#
+# This code is a fork of https://github.com/alexmilowski/flask-openwhisk with
+# some modifications done here https://github.com/alvarolopez/flask-openwhisk
+# Original copyright remains with the original author Alex Milowski
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import base64
+import io
+import sys
+
+import flask
+from werkzeug import http
+
+
+def add_body(environ, body, content_type):
+    environ['CONTENT_TYPE'] = content_type
+    if body:
+        environ['wsgi.input'] = io.BytesIO(body)
+        environ['CONTENT_LENGTH'] = str(len(body))
+    else:
+        environ['wsgi.input'] = None
+
+
+block = set(['x-client-ip', 'x-forwarded-for',
+             'x-forwarded-proto', 'x-global-transaction-id'])
+
+
+def add_headers(environ, headers):
+    for header in headers:
+        if header not in block:
+            wsgi_name = "HTTP_" + header.upper().replace('-', '_')
+            environ[wsgi_name] = str(headers[header])
+
+
+def invoke(app, args):
+    headers = args.get('__ow_headers', {})
+    environ = {
+        'REQUEST_METHOD': args.get('__ow_method', 'GET').upper(),
+        'SCRIPT_NAME': '',
+        'PATH_INFO': args.get('__ow_path', '/'),
+        'QUERY_STRING': args.get('__ow_query', None),
+        'SERVER_NAME': 'localhost',
+        'SERVER_PORT': '5000',
+        'SERVER_PROTOCOL': 'HTTP/1.1',
+        'SERVER_SOFTWARE': 'flask-openwhisk',
+        'REMOTE_ADDR': headers.get('x-client-ip', '127.0.0.1'),
+        'wsgi.version': (1, 0),
+        'wsgi.url_scheme': headers.get('x-forwarded-proto', 'http'),
+        'wsgi.input': None,
+        'wsgi.errors': sys.stderr,
+        'wsgi.multiprocess': True,
+        'wsgi.multithread': False,
+        'wsgi.run_once': True
+    }
+
+    if environ['REQUEST_METHOD'] in ('POST', 'PUT'):
+        content_type = headers.get('content-type', 'application/octet-stream')
+        parsed_content_type = http.parse_options_header(content_type)
+        raw = args.get('__ow_body')
+        if parsed_content_type[0][0:5] == 'text/':
+            body = raw.encode(parsed_content_type[1].get('charset', 'utf-8'))
+        else:
+            body = base64.b64decode(raw) if raw is not None else None
+        add_body(environ, body, content_type)
+
+    add_headers(environ, headers)
+
+    response = flask.Response.from_app(app.wsgi_app, environ)
+
+    response_type = http.parse_options_header(
+        response.headers.get('Content-Type', 'application/octet-stream'))
+    if response_type[0][0:response_type[0].find('/')] != 'octet-stream':
+        body = response.data.decode(response_type[1].get('charset', 'utf-8'))
+    else:
+        body = base64.b64encode(response.data)
+
+    return {
+        'headers': dict(response.headers),
+        'statusCode': response.status_code,
+        'body': body
+    }

--- a/deepaas/openwisk/proxy.py
+++ b/deepaas/openwisk/proxy.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+# Copyright Apache Software Foundation (ASF)
+# Copyright 2018 Spanish National Research Council (CSIC)
+#
+# This code is based upon the openwhisk-runtime-docker reposiutory [1] from the
+# Apache Software Foundation. Original copyright remains with the original
+# authors
+#
+# [1]: https://github.com/apache/incubator-openwhisk-runtime-docker
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import sys
+
+import flask
+from gevent import wsgi
+from oslo_config import cfg
+
+from deepaas import api
+from deepaas.openwisk import handle
+
+CONF = cfg.CONF
+
+LOG_SENTINEL = 'XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX'
+
+proxy = flask.Flask(__name__)
+proxy.debug = False
+proxy.initialized = False
+
+APP = None
+
+
+# OpenWhisk calls the /init route when initializing the action, therefore we
+# need this route. We use it as a singleton as we do not allow to reinit the
+# action.
+@proxy.route('/init', methods=['POST'])
+def init():
+    global APP
+
+    try:
+        if APP is None:
+            APP = api.get_app()
+        return ('OK', 200)
+    except Exception as e:
+        response = flask.jsonify({'error': 'Internal error. {}'.format(e)})
+        response.status_code = 500
+        return complete(response)
+
+
+# OpenWhisk will call the /run route when an action is invoked
+@proxy.route('/run', methods=['POST', "GET"])
+def run():
+    message = flask.request.get_json(force=True, silent=True)
+    if message and not isinstance(message, dict):
+        return error_bad_request()
+    else:
+        args = message.get('value', {}) if message else {}
+        if not isinstance(args, dict):
+            return error_bad_request()
+
+    if APP is not None:
+        try:
+            result = handle.invoke(APP, args)
+            response = flask.jsonify(result)
+            response.status_code = 200
+        except Exception as e:
+            response = flask.jsonify({'error': 'Internal error. {}'.format(e)})
+            response.status_code = 500
+    else:
+        response = flask.jsonify({'error': 'The action is not intialized. '
+                                           'See logs for details.'})
+        response.status_code = 502
+    return complete(response)
+
+
+def error_bad_request():
+    response = flask.jsonify({'error': 'The action did not receive a '
+                              'dictionary as an argument.'})
+    response.status_code = 400
+    return complete(response)
+
+
+def complete(response):
+    # Add sentinel to stdout/stderr
+    sys.stdout.write('%s\n' % LOG_SENTINEL)
+    sys.stdout.flush()
+    sys.stderr.write('%s\n' % LOG_SENTINEL)
+    sys.stderr.flush()
+    return response
+
+
+def main():
+    server = wsgi.WSGIServer((CONF.listen_ip, 8080), proxy, log=None)
+    server.serve_forever()

--- a/deepaas/openwisk/proxy.py
+++ b/deepaas/openwisk/proxy.py
@@ -50,7 +50,7 @@ def init():
 
     try:
         if APP is None:
-            APP = api.get_app()
+            APP = api.get_app(doc=False)
         return ('OK', 200)
     except Exception as e:
         response = flask.jsonify({'error': 'Internal error. {}'.format(e)})

--- a/doc/source/cli/deepaas-wsk.rst
+++ b/doc/source/cli/deepaas-wsk.rst
@@ -1,0 +1,36 @@
+===========
+deepaas-run
+===========
+
+Synopsis
+========
+
+:program:`deepaas-wsk` [options]
+
+Description
+===========
+
+:program:`deepaas-wsk` is a server daemon that serves the models that are
+loaded through the ``deepaas.models`` entrypoint as an OpenWhisk action.
+API.
+
+Options
+=======
+
+TBD.
+
+Files
+=====
+
+TBD.
+
+See Also
+========
+
+TBD.
+
+Reporting Bugs
+==============
+
+Bugs are managed at `Launchpad <https://github.com/indigo-dc/deepaas>`__
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -34,6 +34,7 @@ what you are looking for.
    installation
    quickstart
    configuration/index
+   openwhisk
    devel
 
 API reference

--- a/doc/source/openwhisk.rst
+++ b/doc/source/openwhisk.rst
@@ -1,0 +1,25 @@
+.. _openwhisk:
+
+DEEPaaS API as an OpenWhisk action
+==================================
+
+DEEPaaS API can be executed inside a Docker container as an OpenWhisk Docker
+action. In your Dockerfile, you have to ensure that you execute ``deepaas-run``
+with the ``--openwhisk-detect`` switch, as follows:
+
+.. code-block:: console
+
+   (...)
+   CMD ["sh", "-c", "deepaas-run --openwhisk --listen-ip 0.0.0.0"]
+
+For a complete example, check the `DEEP OC Generic Container
+<https://github.com/deephdc/DEEP-OC-generic-container>` or the ``Dockerfile``
+that is included within the DEEPaaS API repository.
+
+With that Dockerfile you can build your docker container and create the
+corresponding OpenWhisk action:
+
+.. code-block:: console
+
+   docker build -t foobar/container .
+   wsk action create action-name --docker foobar/container --web true

--- a/releasenotes/notes/openwish-proxy-c9c15eef91da0579.yaml
+++ b/releasenotes/notes/openwish-proxy-c9c15eef91da0579.yaml
@@ -1,0 +1,13 @@
+---
+prelude: >
+    This release add support for running DEEPaaS inside an OpenWhisk Docker
+    action container, without modifying the code or without external
+    dependencies.
+features:
+  - |
+    We have added support for running DEEPaaS as an OpenWhisk Docker action.
+    When DEEPaaS is invoked via `deepaas-run --openwhisk-detect` it will detect
+    if it is running inside an OpenWhisk Docker container, thus it will spawn a
+    proxy service that will get the requests and invoke the corresponding model
+    function. A new command `deepaas-wsk` is also provided as a command line
+    option to force the execution of DEEPaaS in OpenWhisk mode.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ flask-restplus>=0.12.1
 Flask>=1.0.2
 Werkzeug>=0.14.1
 stevedore>=1.20.0 # Apache-2.0
+
+gevent==1.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ packages =
 [entry_points]
 console_scripts = 
     deepaas-run = deepaas.cmd.run:main
+    deepaas-wsk = deepaas.cmd.wsk:main
 
 oslo.config.opts =
     deepaas = deepaas.opts:list_opts


### PR DESCRIPTION
# Description

This commit adds support for running a DEEPaaS container as an OpenWhisk
Docker action. We implement a proxy service that handles the OpenWhisk
requests and translating this to the flask request that DEEPaaS will
handle.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
