### PR TITLE
test-args patch

### DIFF
--- a/deepaas/api/v1.py
+++ b/deepaas/api/v1.py
@@ -189,8 +189,8 @@ for model_name, model_obj in model.MODELS.items():
                 # FIXME(aloga): only handling one file, see comment on top of
                 # file and [1] for more details
                 # [1] https://github.com/noirbizarre/flask-restplus/issues/491
-                # data = [f.read() for f in args["files"]]
-                # data = [args["files"].read()]
+                args["files"] = [args["files"]]
+
                 ret = self.model_obj.predict_data(args)
             elif args["urls"]:
                 ret = self.model_obj.predict_url(args)

--- a/releasenotes/notes/allow-passing-args-dbadafef832265e9.yaml
+++ b/releasenotes/notes/allow-passing-args-dbadafef832265e9.yaml
@@ -5,3 +5,7 @@ features:
     module entry point, allowing to expose those arguments through the API.
 fixes:
   - https://jira.deep-hybrid-datacloud.eu/browse/DPD-489
+issues:
+  - The 0.5.0 version stops passing down the raw data when making a prediction,
+	and passes down the file objects. This breaks backwards compatibility with
+	the 0.4.0 version.


### PR DESCRIPTION
To be merged at `1.0` release because the `test-args patch` commit is breaking functionality (even with respect to the old `test args` branch, merged at `0.5`).

**Commit name: test-args patch**

This is a patch to be consistent with the previous version of DEEPaaS, in which we returned a list of len 1 (because of the [Swagger bug](https://github.com/indigo-dc/DEEPaaS/blob/master/deepaas/api/v1.py#L35-L39)) for the `args['files']` parameter in the `predict_data` method.

I forgot to add this in the `test-args` branch and was returning directly a `FileStorage` object (not a list of `FileStorage` objects).

**Commit name: fix test args parser**

This is a patch to fig a bug in test parser that keep piling up the test args of the previous modules.

For example if the module loading order is image-classification and then satellites, the image classification predict method module would show the test args of image-classification but the satellites predict method would show the test args of **both** satellites and image-classification.