### PR TITLE
Output can be image or json for inference

### DIFF
--- a/deepaas/api/v1.py
+++ b/deepaas/api/v1.py
@@ -57,10 +57,10 @@ data_parser.add_argument('url',
                          action="append")
 
 data_parser.add_argument('output',
-                         help="Output format: json or image (only if available in the model)",
+                         help="Output format: json or image",
                          type=str,
                          default='json',
-                         choices=['json','image'],
+                         choices=['json', 'image'],
                          dest='output',
                          required=False,
                          action="append")

--- a/deepaas/api/v1.py
+++ b/deepaas/api/v1.py
@@ -56,6 +56,16 @@ data_parser.add_argument('url',
                          required=False,
                          action="append")
 
+data_parser.add_argument('output',
+                         help="Output format: json or image (only if available in the model)",
+                         type=str,
+                         default='json',
+                         choices=['json','image'],
+                         dest='output',
+                         required=False,
+                         action="append")
+
+
 model_links = api.model('Location', {
     "rel": fields.String(required=True),
     "href": fields.Url(required=True)


### PR DESCRIPTION
# Description

Included a feature to choose json or image as output for the inference.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

It was tested on the posenet use case (which contains the feature of showing also an image as output) and for one of the old use cases returning only json

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
