### PR TITLE
Install netifaces from APT repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,14 @@ RUN apt-get update && \
 RUN apt-get install -y --no-install-recommends \
         git \
         curl \
+        python-netifaces \
         python-setuptools \
         python-pip \
         python-wheel \
+        python3-netifaces \
         python3-setuptools \
         python3-pip \
-        python3-wheel
+        python3-wheel 
 
 WORKDIR /srv
 


### PR DESCRIPTION
netifaces (dependency netifaces->oslo.log->oslo.utils) fails to build on
the Dockerfile, due to a dependency error (GCC is not installed in the
original image).