### PR TITLE
fix parsers overwrite

### DIFF
--- a/deepaas/api/v1.py
+++ b/deepaas/api/v1.py
@@ -136,7 +136,7 @@ response = api.model('ModelResponse', {
 })
 
 # It is better to create different routes for different models instead of using
-# the Flask pluggable views. Different models may require different paramters,
+# the Flask pluggable views. Different models may require different parameters,
 # therefore we need to do like this.
 #
 # Therefore, in the next lines we iterate over the loaded models and create
@@ -177,12 +177,13 @@ for model_name, model_obj in model.MODELS.items():
     class ModelPredict(flask_restplus.Resource):
         model_name = model_name
         model_obj = model_obj
+        test_parser = test_parser
 
         @api.expect(test_parser)
         def post(self):
             """Make a prediction given the input data."""
 
-            args = test_parser.parse_args()
+            args = self.test_parser.parse_args()
 
             if (not any([args["urls"], args["files"]]) or
                     all([args["urls"], args["files"]])):
@@ -211,13 +212,14 @@ for model_name, model_obj in model.MODELS.items():
     class ModelTrain(flask_restplus.Resource):
         model_name = model_name
         model_obj = model_obj
+        train_parser = train_parser
 
         @api.doc('Retrain model')
         @api.expect(train_parser)
         def put(self):
             """Retrain model with available data."""
 
-            args = train_parser.parse_args()
+            args = self.train_parser.parse_args()
             ret = self.model_obj.train(args)
             # FIXME(aloga): what are we returning here? We need to marshal the
             # response!!


### PR DESCRIPTION
## Description

This is a fix to make the argument's parsers (both `train` and `test`) members of their respective classes.

The bug arises when several modules are present at the same time. If the parsers are not members of their class, they are are overwritten by the parser of the last loaded module due to the `for` loop structure of the module loading.

The bug was hard to find because it was only noticeable once the method was called: that is, the parameters for each module where correctly displayed in the API interface (with `@api.expect()`) but the parsing was done on the overwritten parser (`args = parser.parse_args()`).


## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested for both `train` and `predict` methods with three different modules simultaneously installed.
