### PR TITLE
fix default content type

### DIFF
--- a/deepaas/api/v2/predict.py
+++ b/deepaas/api/v2/predict.py
@@ -18,6 +18,7 @@ from aiohttp import web
 import aiohttp_apispec
 from webargs import aiohttpparser
 import webargs.core
+import marshmallow
 
 from deepaas.api.v2 import responses
 from deepaas.api.v2 import utils
@@ -36,11 +37,11 @@ def _get_model_response(model_name, model_obj):
 def _get_handler(model_name, model_obj):
     aux = model_obj.get_predict_args()
     accept = aux.get("accept", None)
-    if accept and "application/json" not in accept.validate.choices:
-        accept.validate.choices.insert(0, "application/json")
+    if accept:
         accept.validate.choices.append("*/*")
-        accept.default = "application/json"
-        accept.missing = "application/json"
+        # If no default value use first possible choice:
+        if isinstance(accept.missing, marshmallow.utils._Missing):
+            accept.missing = accept.validate.choices[0]
         accept.location = "headers"
 
     handler_args = webargs.core.dict2schema(aux)

--- a/deepaas/api/v2/predict.py
+++ b/deepaas/api/v2/predict.py
@@ -16,9 +16,9 @@
 
 from aiohttp import web
 import aiohttp_apispec
+import marshmallow
 from webargs import aiohttpparser
 import webargs.core
-import marshmallow
 
 from deepaas.api.v2 import responses
 from deepaas.api.v2 import utils

--- a/doc/source/user/v2-api.rst
+++ b/doc/source/user/v2-api.rst
@@ -156,7 +156,7 @@ string, and will be returned in the following JSON response::
       "predictions": "<model response as string>"
    }
 
-However, it is reccomended that you specify a custom custom response schema.
+However, it is recommended that you specify a custom response schema.
 This way the API exposed will be richer and it will be easier for developers to
 build applications against your API, as they will be able to discover the
 response schemas from your endpoints.
@@ -255,15 +255,9 @@ types that you are able to return as follows::
                 validate=validate.OneOf(["text/plain"]),
          }
 
-Consequantly, the predict calls will receive an ``accept`` argument containing
-the content type requested by the user.
-
-.. important:: Please be aware the the JSON content type (i.e.
-   ``application/json``) must be always supported and it will be defined and
-   presented to the user even if you do not define it in your ``accept``
-   argument. This means that if you do not receive an accept argument, or the
-   accept argument is empty you **must** return content that can be redered as
-   a JSON following the schema definition described above.
+Consequently, the predict calls will receive an ``accept`` argument containing
+the content type requested by the user. Find `here <https://www.iana.org/assignments/media-types/media-types.xhtml>`_
+a comprehensive list of possible content types.
 
 Using classes
 -------------


### PR DESCRIPTION
**Changes**
* do _not_ automatically add `application/json` to the content-type list for modules that already provide an `accept` arg with possible content-types
* use the first possible content-type choice as `default` if no `default` has been provided
