### PR TITLE
Fix cancellation of trainings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@
 
 <img src="https://marketplace.deep-hybrid-datacloud.eu/images/logo-deep.png" width=200 alt="DEEP-Hybrid-DataCloud logo"/>
 
-DEEP as a Service (DEEPaaS) is a REST API that is focused on providing access
-to machine learning models. By using DEEPaaS users can easily run a REST API
-in front of their model, thus accessing its functionality via HTTP calls.
+DEEP as a Service API (DEEPaaS API) is a REST API built on
+[aiohttp](https://docs.aiohttp.org/) that allows to provide easy access to
+machine learning, deep learning and artificial intelligence models. By using
+the DEEPaaS API users can easily run a REST API in front of their model, thus
+accessing its functionality via HTTP calls. DEEPaaS API leverages the [OpenAPI
+specification](https://github.com/OAI/OpenAPI-Specification).
+
+# Documentation
+
+The DEEPaaS documentation is hosted on [Read the Docs](https://deepaas.readthedocs.io/).
+
 
 ## Quickstart
 
@@ -22,7 +30,7 @@ The best way to quickly try the DEEPaaS API is through:
 This command will install a virtualenv (in the `virtualenv` directory) with
 DEEPaaS and all its dependencies and will run the DEEPaaS REST API, listening
 on `127.0.0.1:5000`. If you browse to `http://127.0.0.1:5000` you will get the
-swagger documentation page.
+Swagger documentation page (i.e. the Swagger web UI).
 
 ### Develop mode
 
@@ -30,10 +38,6 @@ If you want to run the code in develop mode (i.e. `pip install -e`), you can
 issue the following command before:
 
     make develop
-
-# Documentation
-
-The DEEPaaS documentation is hosted on [Read the Docs](https://deepaas.readthedocs.io/).
 
 
 # Citing
@@ -64,3 +68,10 @@ You can also use the following BibTeX entry:
         year = {2019},
         month = {10},
         day = {25},}
+
+# Acknowledgements
+
+This software has been developed within the DEEP-Hybrid-DataCloud (Designing
+and Enabling E-infrastructures for intensive Processing in a Hybrid DataCloud)
+project that has received funding from the European Union’s Horizon 2020
+research and innovation programme under grant agreement No 777435.

--- a/deepaas/tests/test_v2_models.py
+++ b/deepaas/tests/test_v2_models.py
@@ -69,7 +69,8 @@ class TestV2Model(base.TestCase):
         self.assertRaises(NotImplementedError, m.train)
         self.assertRaises(NotImplementedError, m.get_train_args)
 
-    def test_bad_schema(self):
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
+    def test_bad_schema(self, m_clean):
         class Model(object):
             schema = []
 
@@ -80,7 +81,8 @@ class TestV2Model(base.TestCase):
             self.app
         )
 
-    def test_validate_no_schema(self):
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
+    def test_validate_no_schema(self, m_clean):
         class Model(object):
             schema = None
 
@@ -91,7 +93,8 @@ class TestV2Model(base.TestCase):
             None
         )
 
-    def test_invalid_schema(self):
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
+    def test_invalid_schema(self, m_clean):
         class Model(object):
             schema = object()
 
@@ -102,7 +105,8 @@ class TestV2Model(base.TestCase):
             self.app
         )
 
-    def test_marshmallow_schema(self):
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
+    def test_marshmallow_schema(self, m_clean):
         class Schema(marshmallow.Schema):
             foo = m_fields.Str()
 
@@ -118,7 +122,8 @@ class TestV2Model(base.TestCase):
             {"foo": 1.0}
         )
 
-    def test_dict_schema(self):
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
+    def test_dict_schema(self, m_clean):
         class Model(object):
             schema = {
                 "foo": m_fields.Str()
@@ -151,8 +156,9 @@ class TestV2Model(base.TestCase):
         for arg, val in itertools.chain(pargs.items(), targs.items()):
             self.assertIsInstance(val, fields.Field)
 
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
     @test_utils.unittest_run_loop
-    async def test_dummy_model_with_wrapper(self):
+    async def test_dummy_model_with_wrapper(self, m_clean):
         w = v2_wrapper.ModelWrapper("foo", v2_test.TestModel(), self.app)
         task = w.predict()
         await task
@@ -175,8 +181,10 @@ class TestV2Model(base.TestCase):
         for arg, val in itertools.chain(pargs.items(), targs.items()):
             self.assertIsInstance(val, fields.Field)
 
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
     @test_utils.unittest_run_loop
-    async def test_model_with_not_implemented_attributes_and_wrapper(self):
+    async def test_model_with_not_implemented_attributes_and_wrapper(self,
+                                                                     m_clean):
         w = v2_wrapper.ModelWrapper("foo", object(), self.app)
 
         # NOTE(aloga): Cannot use assertRaises here directly, as testtools
@@ -203,16 +211,18 @@ class TestV2Model(base.TestCase):
         for arg, val in itertools.chain(pargs.items(), targs.items()):
             self.assertIsInstance(val, fields.Field)
 
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
     @mock.patch('deepaas.model.loading.get_available_models')
-    def test_loading_ok(self, mock_loading):
+    def test_loading_ok(self, mock_loading, m_clean):
         mock_loading.return_value = {uuid.uuid4().hex: "bar"}
         deepaas.model.v2.register_models(self.app)
         mock_loading.assert_called()
         for m in deepaas.model.v2.MODELS.values():
             self.assertIsInstance(m, v2_wrapper.ModelWrapper)
 
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
     @mock.patch('deepaas.model.loading.get_available_models')
-    def test_loading_ok_singleton(self, mock_loading):
+    def test_loading_ok_singleton(self, mock_loading, m_clean):
         mock_loading.return_value = {uuid.uuid4().hex: "bar"}
         deepaas.model.v2.register_models(self.app)
         deepaas.model.v2.register_models(self.app)
@@ -220,8 +230,9 @@ class TestV2Model(base.TestCase):
         for m in deepaas.model.v2.MODELS.values():
             self.assertIsInstance(m, v2_wrapper.ModelWrapper)
 
+    @mock.patch("deepaas.model.v2.wrapper.ModelWrapper._setup_cleanup")
     @mock.patch('deepaas.model.loading.get_available_models')
-    def test_loading_error(self, mock_loading):
+    def test_loading_error(self, mock_loading, m_clean):
         mock_loading.return_value = {}
         deepaas.model.v2.register_models(self.app)
         mock_loading.assert_called()


### PR DESCRIPTION
If a user performed a training -> cancel -> training -> cancel, the last
cancel did not terminate properly and the API blocked, as the process
did not join.

Since we are using a process pool with only 1 slot, we can get the
running processes in the pool and kill them.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
