### PR TITLE
Ignacio br0

### DIFF
--- a/deepaas/model/v2/wrapper.py
+++ b/deepaas/model/v2/wrapper.py
@@ -347,24 +347,27 @@ class ModelWrapper(object):
         return aux
 
 
+class NonDaemonProcess(multiprocessing.context.SpawnProcess):
+    """Processes must use 'spawn' instead of 'fork' (which is the default
+    in Linux) in order to work CUDA [1] or Tensorflow [2].
+
+    [1] https://pytorch.org/docs/stable/notes/multiprocessing.html
+    #cuda-in-multiprocessing
+    [2] https://github.com/tensorflow/tensorflow/issues/5448
+    #issuecomment-258934405
+    """
+    @property
+    def daemon(self):
+        return False
+
+    @daemon.setter
+    def daemon(self, value):
+        pass
+
+
 class NonDaemonPool(multiprocessing.pool.Pool):
-    def Process(self, *args, **kwds):
-        proc = super(NonDaemonPool, self).Process(*args, **kwds)
-
-        class NonDaemonProcess(proc.__class__):
-            """Monkey-patch process to ensure it is never daemonized"""
-
-            @property
-            def daemon(self):
-                return False
-
-            @daemon.setter
-            def daemon(self, val):
-                pass
-
-        proc.__class__ = NonDaemonProcess
-
-        return proc
+    # Based on https://stackoverflow.com/questions/6974695/
+    Process = NonDaemonProcess
 
 
 class CancellablePool(object):
@@ -374,7 +377,7 @@ class CancellablePool(object):
         self._change = asyncio.Event()
 
     def _new_pool(self):
-        return NonDaemonPool(1)
+        return NonDaemonPool(1, context=multiprocessing.get_context('spawn'))
 
     async def apply(self, fn, *args):
         """


### PR DESCRIPTION
# Description

This a PR to fix issues over the training process in DEEPaaS.

The current DEEPaaS runs the training in a separate child process in order to be Cancellable. This process is created using the multiprocessing module. It is a known fact that CUDA and multiprocessing don't work out-of-the-box together very well [1]. In addition in the case of Tensorflow this doesn't work very well even in the case of using CPUs [2].

The fix proposed changes the process' start method from `fork` (default in Linux) to `spawn` [3].

[1] https://pytorch.org/docs/stable/notes/multiprocessing.html#cuda-in-multiprocessing
[2] https://github.com/tensorflow/tensorflow/issues/5448#issuecomment-258934405
[3] https://docs.python.org/3.6/library/multiprocessing.html#contexts-and-start-methods

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests of the training function (and cancellation) have been performed using Tensorflow (both on CPU and GPU).
