### PR TITLE
Pin webargs version <6.0.0

### DIFF
--- a/deepaas/tests/test_v1_api.py
+++ b/deepaas/tests/test_v1_api.py
@@ -78,14 +78,14 @@ class TestApiV1(base.TestCase):
         ret = await self.client.post(
             "/v1/models/deepaas-test/predict",
             data={"url": "http://example.org/"})
-        self.assertEqual(400, ret.status)
+        self.assertEqual(501, ret.status)
 
     @test_utils.unittest_run_loop
     async def test_predict_various_urls_not_implemented(self):
         ret = await self.client.post(
             "/v1/models/deepaas-test/predict",
             data={"url": ["http://example.org/", "http://example.com"]})
-        self.assertEqual(400, ret.status)
+        self.assertEqual(501, ret.status)
 
     @test_utils.unittest_run_loop
     async def test_get_metadata(self):

--- a/deepaas/tests/test_v2_api.py
+++ b/deepaas/tests/test_v2_api.py
@@ -92,12 +92,13 @@ class TestApiV2(base.TestCase):
     async def test_predict_no_parameters(self):
         ret = await self.client.post("/v2/models/deepaas-test/predict/")
         json = await ret.json()
+        print(json)
         self.assertDictEqual(
             {
                 'parameter': ['Missing data for required field.'],
                 'data': ['Missing data for required field.']
             },
-            json["json"]
+            json
         )
         self.assertEqual(422, ret.status)
 

--- a/releasenotes/notes/add-new-cli-669061dfada81f5c.yaml
+++ b/releasenotes/notes/add-new-cli-669061dfada81f5c.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Include a new command line tool to execute inference and prediction calls 
+    from the shell, whitout spawning a server and making cURL requests to it.
+    This is useful for execution of batch tasks in a HPC/HTC or batch system
+    cluster.

--- a/releasenotes/notes/bug-fixes-73cfa32ffb5bdbb0.yaml
+++ b/releasenotes/notes/bug-fixes-73cfa32ffb5bdbb0.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    This new release fixes an error introduced by `webargs` in its 6.0.0
+    version.  Since we cannot yet fix it (`aiohttp-webargs` needs to be updated
+    as well) we pin webargs to the 5.X.X versions
+    https://github.com/indigo-dc/DEEPaaS/issues/82
+  - | 
+    Set `debug` in OpenWhisk mode as configured by the user.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ aiohttp-apispec>=2.2.0
 
 werkzeug>=0.16.0
 marshmallow>=3.2.1
-webargs>=5.5.2
+webargs>=5.5.2,<6.0.0
 
 jsonschema>=2.6.0


### PR DESCRIPTION
Webargs >= 6.0.0 introduced a breaking change where schema fields may
not specify a location any longer. We need to change our code to specify
per-location schemas (easy) but aiohttp-apispec is not ready yet until
maximdanilchenko/aiohttp-apispec/83 is fixed.

This change pins the webargs version to something below 6.0.0 so that
things are not borken.

Fixes #82