### PR TITLE
add original_filename in UploadedFile()

### DIFF
--- a/deepaas/model/v2/wrapper.py
+++ b/deepaas/model/v2/wrapper.py
@@ -40,7 +40,8 @@ CONF = cfg.CONF
 
 UploadedFile = collections.namedtuple("UploadedFile", ("name",
                                                        "filename",
-                                                       "content_type"))
+                                                       "content_type",
+                                                       "original_filename"))
 """Class to hold uploaded field metadata when passed to model's methods
 
 .. py:attribute:: name
@@ -53,8 +54,15 @@ UploadedFile = collections.namedtuple("UploadedFile", ("name",
 
 .. py:attribute:: content_type
 
-   Content-type of the uploaded file.
+   Content-type of the uploaded file
+
+.. py:attribute:: original_filename
+
+   Filename of the original file being uploaded.
 """
+
+# set defaults to None, mainly for compatibility (vkoz)
+UploadedFile.__new__.__defaults__ = (None, None, None, None)
 
 
 class ModelWrapper(object):
@@ -266,6 +274,7 @@ class ModelWrapper(object):
                     name=val.name,
                     filename=name,
                     content_type=val.content_type,
+                    original_filename=val.filename
                 )
                 kwargs[key] = aux
                 # FIXME(aloga); cleanup of tmpfile here


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are
required for this change. Please note that there may be some sections that may
not apply to your change, in that case feel free to delete them.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality):
   adds "original_filename" attribute in UploadedFile(), wrapper.py, to access filename of the original file being uploaded. Set defaults to "None", so that adding the parameter does not break previous instantiations of UploadedFile()
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- [x] Test A
installed updated deepaas version in a container with the application (deephdc/dogs_breed_det), checked that the application correctly accesses new parameter (original_filename) and does not break.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
