### PR TITLE
unify train and predict pools

### DIFF
--- a/deepaas/api/v2/predict.py
+++ b/deepaas/api/v2/predict.py
@@ -72,7 +72,10 @@ def _get_handler(model_name, model_obj):
             task = self.model_obj.predict(**args)
             await task
 
-            ret = task.result()
+            ret = task.result()['output']
+
+            if isinstance(ret, model.v2.wrapper.ReturnedFile):
+                ret = open(ret.filename, 'rb')
 
             accept = args.get("accept", "application/json")
             if accept != "application/json":

--- a/deepaas/config.py
+++ b/deepaas/config.py
@@ -42,19 +42,13 @@ print to the standard output and error (i.e. stdout and stderr) through the
 "/debug" endpoint. Default is to not provide this information. This will not
 provide logging information about the API itself.
 """),
-    cfg.IntOpt('predict-workers',
+    cfg.IntOpt('workers',
                short='p',
                default=1,
                help="""
-Specify the number of workers to spawn for prediction tasks. If using a CPU you
-probably want to increase this number, if using a GPU probably you want to
-leave it to 1. (defaults to 1)
-"""),
-    cfg.IntOpt('train-workers',
-               default=1,
-               help="""
-Specify the number of workers to spawn for training tasks. Unless you know what
-you are doing you should leave this number to 1. (defaults to 1)
+Specify the number of workers to spawn. If using a CPU you probably want to
+increase this number, if using a GPU probably you want to leave it to 1.
+(defaults to 1)
 """),
     cfg.IntOpt('client-max-size',
                default=0,

--- a/deepaas/tests/test_v2_models.py
+++ b/deepaas/tests/test_v2_models.py
@@ -162,7 +162,7 @@ class TestV2Model(base.TestCase):
         w = v2_wrapper.ModelWrapper("foo", v2_test.TestModel(), self.app)
         task = w.predict()
         await task
-        ret = task.result()
+        ret = task.result()['output']
         self.assertDictEqual(
             {'date': '2019-01-1',
              'labels': [{'label': 'foo', 'probability': 1.0}]},


### PR DESCRIPTION
This fixes GPU out-of-memory problems that happened when we had two different pools (for predict and train). When we did train then predict sequentially (or viceversa) each pool wanted to have the whole GPU so out-of-memory errors happened. This won't fix out-of-memory errors when running parallel tasks on GPU (errors which also happened before).

CPU deployments shouldn't be affected.

This has been tested with the image classification package on tf 1.14 and GPU (GeForce GTX 1080).
**Summary of results:**
* predict then train: OK
* train then predict: OK
* train then train: OK
* predict then predict: OK
* predict in parallel (2 workers): Out of of memory.
* train in parallel (2 workers): Out of of memory.

Additional tests on CPU:
* warm: OK
* predict in parallel (2 workers): OK
