### PR TITLE
Decouple ModelWrapper from api

### DIFF
--- a/deepaas/model/v2/wrapper.py
+++ b/deepaas/model/v2/wrapper.py
@@ -102,7 +102,7 @@ class ModelWrapper(object):
     :raises HTTPInternalServerError: in case that a model has defined
         a response schema that is not JSON schema valid (DRAFT 4)
     """
-    def __init__(self, name, model_obj, app):
+    def __init__(self, name, model_obj, app=None):
         self.name = name
         self.model_obj = model_obj
         self._app = app
@@ -112,7 +112,8 @@ class ModelWrapper(object):
         self._workers = CONF.workers
         self._executor = self._init_executor()
 
-        self._setup_cleanup()
+        if self._app is not None:
+            self._setup_cleanup()
 
         schema = getattr(self.model_obj, "schema", None)
 


### PR DESCRIPTION
Decouple the the ModelWrapper from the api so that one does not need to instantiate an aiohttp web Application to use the ModelWrapper.

Related with the development of the CLI feature.

This is a non breaking change.


