### PR TITLE
Relax Python >=3.7 dependency to Python >= 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [2.1.0]
+### Added
+### Changed
+- DEEPaaS dependency on Python is relaxed, again, to >= 3.6
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [2.0.0]
+### Added
+### Changed
 - DEEPaaS now requires Python >= 3.7
 - Start using a changelog.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ project_urls =
     Bug Tracker = https://github.com/indigo-dc/deepaas/issues
     Documentation = https://deepaas.readthedocs.io/
 
-python-requires = >=3.7
+python-requires = >=3.6
 
 license = Apache-2
 license_file = LICENSE
@@ -30,6 +30,7 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
Although Py36 has reached its EOL it is better to relax the dependency
on the Python version, as otherwise DEEPaaS will not work for some TF
Docker versions, etc.
