### PR TITLE
Relax Python >=3.7 dependency to Python >= 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [2.1.0]
+### Added
+### Changed
+- DEEPaaS dependency on Python is relaxed, again, to >= 3.6
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [2.0.0]
+### Added
+### Changed
 - DEEPaaS now requires Python >= 3.7
 - Start using a changelog.
 

--- a/Dockerfile.CI
+++ b/Dockerfile.CI
@@ -1,0 +1,32 @@
+FROM indigodatacloud/ci-images:base-u18
+MAINTAINER Pablo Orviz <orviz@ifca.unican.es>
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y wget \
+                                                  git \
+                                                  python3.7 python3-dev python-pip \
+						  python-setuptools python-wheel \
+                                                  python3-wheel python3-pip python3-venv \
+						  build-essential \
+                                                  libcurl4-gnutls-dev \
+                                                  libffi-dev \
+                                                  libssl-dev \
+                                                  libxml2-dev \
+                                                  libxslt1-dev \
+						  libgnutls28-dev \
+                                                  default-libmysqlclient-dev libsqlite3-dev \
+						  curl \
+						  tox flake8 pylint pydocstyle pep8 bandit \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
+# otherwise issues with twine<=1.10.0
+RUN pip install twine==1.11.0
+RUN pip install -U wheel setuptools
+
+# Standard SSH port
+EXPOSE 22
+
+# Default command
+CMD ["/usr/sbin/sshd", "-D"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,28 +108,5 @@ pipeline {
             }
         }
 
-        stage('Notifications') {
-            when {
-                buildingTag()
-            }
-	    steps {
-                JiraIssueNotification(
-                    'DEEP',
-                    'DPM',
-                    '10204',
-                    "[preview-testbed] New DEEP-as-a-Service version ${env.BRANCH_NAME} available",
-                    "Check new artifacts at:\n\t- Docker image: [${dockerhub_image_id}:${env.BRANCH_NAME}|https://hub.docker.com/r/${dockerhub_image_id}/tags/]\n",
-                    ['wp3', 'preview-testbed', "DEEPaaS-${env.BRANCH_NAME}"],
-                    'Task',
-                    'mariojmdavid',
-                    ['wgcastell',
-                     'vkozlov',
-                     'dlugo',
-                     'keiichiito',
-                     'laralloret',
-                     'ignacioheredia']
-                )
-            }
-        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
             }
             post {
                 always {
-                    WarningsReport('Pep8')
+                    recordIssues(tools: [flake8()])
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,22 +45,6 @@ pipeline {
             }
         }
 
-        stage('Security scanner') {
-            steps {
-                ToxEnvRun('bandit-report')
-                script {
-                    if (currentBuild.result == 'FAILURE') {
-                        currentBuild.result = 'UNSTABLE'
-                    }
-                }
-            }
-            post {
-                always {
-                    HTMLReport("/tmp/bandit", 'index.html', 'Bandit report')
-                }
-            }
-        }
-
         stage('Dependency check') {
             steps {
                 ToxEnvRun('pip-missing-reqs')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,21 +45,6 @@ pipeline {
             }
         }
 
-        stage('Metrics gathering') {
-            agent {
-                label 'sloc'
-            }
-            steps {
-                checkout scm
-                SLOCRun()
-            }
-            post {
-                success {
-                    SLOCPublish()
-                }
-            }
-        }
-
         stage('Security scanner') {
             steps {
                 ToxEnvRun('bandit-report')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,22 +62,8 @@ pipeline {
         }
 
         stage('Dependency check') {
-            agent {
-                label 'docker-build'
-            }
             steps {
-                checkout scm
-                OWASPDependencyCheckRun("$WORKSPACE/DEEPaaS/deepaas", project="DEEPaaS")
-            }
-            post {
-                always {
-                    OWASPDependencyCheckPublish(report='**/dependency-check-report.xml')
-                    HTMLReport(
-                        "$WORKSPACE/DEEPaaS/deepaas",
-                        'dependency-check-report.html',
-                        'OWASP Dependency Report')
-                    deleteDir()
-                }
+                ToxEnvRun('pip-missing-reqs')
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,11 @@
 
 pipeline {
     agent {
-        label 'python3.6'
+        dockerfile {
+            filename 'Dockerfile.CI'
+        }
     }
-    
+
     environment {
         dockerhub_repo = "indigodatacloud/deepaas"
         dockerhub_image_id = ""

--- a/deepaas/cmd/run.py
+++ b/deepaas/cmd/run.py
@@ -48,6 +48,7 @@ requests.
     cfg.BoolOpt('openwhisk-detect',
                 short='w',
                 default=False,
+                deprecated_for_removal=True,
                 help="""
 Run as an OpenWhisk action.
 

--- a/deepaas/openwhisk/handle.py
+++ b/deepaas/openwhisk/handle.py
@@ -98,7 +98,7 @@ async def invoke(app, request, args):
         rel_url=path,
         headers=get_headers(headers)
     )
-    request._payload = streams.StreamReader(request._payload._protocol)
+    request._payload = streams.StreamReader(request._payload._protocol, 0)
     request._payload.feed_data(body)
     request._payload.feed_eof()
 

--- a/deepaas/openwhisk/proxy.py
+++ b/deepaas/openwhisk/proxy.py
@@ -22,6 +22,7 @@
 # under the License.
 
 import sys
+import warnings
 
 from aiohttp import web
 from oslo_config import cfg
@@ -32,6 +33,7 @@ from deepaas.openwhisk import handle
 cli_opts = [
     cfg.StrOpt('base-openwhisk-path',
                default='/api/v1/web',
+               deprecated_for_removal=True,
                help="""
 Base path where OpenWhisk web actions are served.
 
@@ -148,6 +150,12 @@ def complete(response):
 
 
 def main():
+    msg = ("\033[0;31;40m WARNING: You are using the OpenWhisk integration! "
+           "This integration is marked for removal in the next major version "
+           "of the API. Please get in touch with the developers if you still "
+           "require it. \033[0m")
+
+    warnings.warn(msg, DeprecationWarning)
     proxy = web.Application(
         debug=CONF.debug,
         client_max_size=CONF.client_max_size,

--- a/deepaas/tests/test_v2_models.py
+++ b/deepaas/tests/test_v2_models.py
@@ -140,10 +140,12 @@ class TestV2Model(base.TestCase):
 
     def test_dummy_model(self):
         m = v2_test.TestModel()
+        pred = m.predict()
+        pred.pop("data")
         self.assertDictEqual(
             {'date': '2019-01-1',
              'labels': [{'label': 'foo', 'probability': 1.0}]},
-            m.predict()
+            pred
         )
         self.assertIsNone(m.train())
         meta = m.get_metadata()

--- a/releasenotes/notes/deprecate-openwhisk-be449ddfb9fa554c.yaml
+++ b/releasenotes/notes/deprecate-openwhisk-be449ddfb9fa554c.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    OpenWhisk integration is marked as deprecated.

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ packages =
     deepaas
 
 [entry_points]
-console_scripts = 
+console_scripts =
     deepaas-run = deepaas.cmd.run:main
     deepaas-wsk = deepaas.cmd.wsk:main
     deepaas-predict = deepaas.cmd.execute:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ project_urls =
     Bug Tracker = https://github.com/indigo-dc/deepaas/issues
     Documentation = https://deepaas.readthedocs.io/
 
-python-requires = >=3.7
+python-requires = >=3.6
 
 license = Apache-2
 license_file = LICENSE
@@ -30,6 +30,7 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 flake8>=3.7.9
 pyflakes>=2.1.1
 
-hacking
+hacking>=1.0.0
 
 bandit>=1.1.0 # Apache-2.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ install_command = pip install -U {opts} {packages}
 whitelist_externals =
   find
   rm
+  mkdir
 setenv =
    VIRTUAL_ENV={envdir}
    LC_ALL=en_US.utf-8

--- a/tox.ini
+++ b/tox.ini
@@ -110,6 +110,6 @@ commands=pip-missing-reqs -d --ignore-file=deepaas/tests/* deepaas
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,H803,H405
+ignore = E123,E125,H803,H405,H216
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
Although Py36 has reached its EOL it is better to relax the dependency
on the Python version, as otherwise DEEPaaS will not work for some TF
Docker versions, etc.

However, tox fails in Python 3.6, so we only test on py37
