### PR TITLE
update the docs

### DIFF
--- a/deepaas/model/v2/base.py
+++ b/deepaas/model/v2/base.py
@@ -122,7 +122,10 @@ class BaseModel(object):
                 "version": "Model version",
             }
 
-        The only fields that are mandatory are 'description' and 'name'.
+        If you want to integrate with the deephdc platform you should
+        provide at least an [``name``, ``author``, ``author-email``,
+         ``license``]. You can nevertheless set them to ``None``
+        if you don't feel like providing the information.
 
         The schema that we are following is the following::
 
@@ -203,7 +206,8 @@ class BaseModel(object):
             able to pass them down. Usually you would populate these with all
             the training hyper-parameters
 
-        :return: TBD
+        :return: You can return any Python object that is JSON parseable
+        (eg. dict, string, float).
         """
         raise NotImplementedError()
 

--- a/doc/source/user/v2-api.rst
+++ b/doc/source/user/v2-api.rst
@@ -13,6 +13,10 @@ Integrating a model into the V2 API (CURRENT)
    API version was ``1.0.0``. Please do not be confused with the ``deepaas``
    `release` (i.e. ``0.5.2``, ``1.0.0``) and the DEEPaaS API version (V1 or V2).
 
+If you want to see an example of a module integrated with deepaas, where those
+methods are actually implemented, please head over to the
+`deephdc demo app <https://github.com/deephdc/demo_app>`__.
+
 Defining what to load
 ---------------------
 


### PR DESCRIPTION
* Updated `get_metadata()` docs

I have deleted the sentence from the `get_metadata()` docstring:

> The only fields that are mandatory are 'description' and 'name'.

because that not really true. One can return an empty dict `{}` and deepaas won't complain.

I have instead replaced it by the actual checks we are performing, in the Jenkins pipeline, on specific metadata fields ([ref](https://github.com/deephdc/deep-check_oc_artifact/blob/d9784e00e4fd01a89c2407e3f17d013518f8c704/check_metadata.sh#L21)). 

* Updated the docs for the output of `train()`

*  Added reference to [demo_app](https://github.com/deephdc/demo_app) for an actual implementation of the methods.