### PR TITLE
#114 - fixed FileField json serialization error in train response

### DIFF
--- a/deepaas/api/v2/train.py
+++ b/deepaas/api/v2/train.py
@@ -15,6 +15,7 @@
 # under the License.
 
 import asyncio
+import collections
 from datetime import datetime
 import uuid
 
@@ -30,6 +31,23 @@ from deepaas import model
 
 LOG = log.getLogger("deepaas.api.v2.train")
 
+UploadedFileInfo = collections.namedtuple(
+    "UploadedFileInfo", ("name", "content_type", "original_filename")
+)
+"""Class to pass the file info returned from build_train_response
+
+.. py:attribute:: name
+
+   Name of the argument where this file is being sent.
+
+.. py:attribute:: content_type
+
+   Content-type of the uploaded file
+
+.. py:attribute:: original_filename
+
+   Filename of the original file being uploaded.
+"""
 
 def _get_handler(model_name, model_obj):  # noqa
     args = webargs.core.dict2schema(model_obj.get_train_args())
@@ -53,6 +71,15 @@ def _get_handler(model_name, model_obj):  # noqa
             ret["date"] = training["date"]
             ret["args"] = training["args"]
             ret["uuid"] = uuid
+
+            for (key, val) in ret["args"].items():
+                if isinstance(val, web.FileField):
+                    aux = UploadedFileInfo(
+                        name=val.name,
+                        content_type=val.content_type,
+                        original_filename=val.filename,
+                    )
+                    ret['args'][key] = aux
 
             if training["task"].cancelled():
                 ret["status"] = "cancelled"

--- a/deepaas/api/v2/train.py
+++ b/deepaas/api/v2/train.py
@@ -49,6 +49,7 @@ UploadedFileInfo = collections.namedtuple(
    Filename of the original file being uploaded.
 """
 
+
 def _get_handler(model_name, model_obj):  # noqa
     args = webargs.core.dict2schema(model_obj.get_train_args())
     args.opts.ordered = True
@@ -72,14 +73,14 @@ def _get_handler(model_name, model_obj):  # noqa
             ret["args"] = training["args"]
             ret["uuid"] = uuid
 
-            for (key, val) in ret["args"].items():
+            for key, val in ret["args"].items():
                 if isinstance(val, web.FileField):
                     aux = UploadedFileInfo(
                         name=val.name,
                         content_type=val.content_type,
                         original_filename=val.filename,
                     )
-                    ret['args'][key] = aux
+                    ret["args"][key] = aux
 
             if training["task"].cancelled():
                 ret["status"] = "cancelled"


### PR DESCRIPTION
# Description

Replacing FileField in the return of build_train_response with a new JSON-serializable class UploadedFileInfo to fix the error. This is a similar approach to that of in pr

Fixes #114

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with the demo_app, while a FileField arg has been added to the train schema.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
