### PR TITLE
feat: support back again Python 3.6 modules

### DIFF
--- a/deepaas/__init__.py
+++ b/deepaas/__init__.py
@@ -15,7 +15,7 @@
 # under the License.
 
 from contextlib import suppress
-import importlib.metadata
+# import importlib.metadata  # does not work with 3.6
 from pathlib import Path
 
 __version__ = "2.5.2"
@@ -32,4 +32,5 @@ def extract_version() -> str:
                 .strip("'\"\n ")
             )
             return f"{version}-dev (at {root_dir})"
-    return importlib.metadata.version(__package__ or __name__.split(".", maxsplit=1)[0])
+    # return importlib.metadata.version(__package__ or __name__.split(".", maxsplit=1)[0])
+    return __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,14 +49,14 @@ deepaas-cli = "deepaas.cmd.cli:main"
 deepaas = "deepaas.opts:list_opts"
 
 [tool.poetry.dependencies]
-python = "^3.10"
-"oslo.log" = "^6.0.0"
-"oslo.config" = "^9.4.0"
-stevedore = "^5.2.0"
-aiohttp = "^3.9.5"
+python = "^3.6"
+"oslo.log" = "^4.8.0"
+"oslo.config" = "^8.8.1"
+stevedore = "^3.5.2"
+aiohttp = "^3.8.6"
 aiohttp-apispec = "^2.2.3"
-Werkzeug = "^3.0.3"
-marshmallow = "^3.21.3"
+Werkzeug = "^2.0.3"
+marshmallow = "^3.14.1"
 webargs = "<6.0.0"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,9 @@ deepaas-run = "deepaas.cmd.run:main"
 deepaas-predict = "deepaas.cmd.execute:main"
 deepaas-cli = "deepaas.cmd.cli:main"
 
-[tool.poetry.plugins] # Optional super table 
+[tool.poetry.plugins] # Optional super table
 
-[tool.poetry.plugins."oslo.config.opts"] 
+[tool.poetry.plugins."oslo.config.opts"]
 deepaas = "deepaas.opts:list_opts"
 
 [tool.poetry.dependencies]
@@ -58,50 +58,6 @@ aiohttp-apispec = "^2.2.3"
 Werkzeug = "^2.0.3"
 marshmallow = "^3.14.1"
 webargs = "<6.0.0"
-
-
-[tool.poetry.group.dev.dependencies]
-tox = "^4.15.1"
-
-
-[tool.poetry.group.test.dependencies]
-pytest = "^8.2.2"
-pytest-aiohttp = "^1.0.5"
-pytest-cov = "^5.0.0"
-fixtures = "^4.1.0"
-reno = "^4.1.0"
-mock = "^5.1.0"
-testtools = "^2.7.1"
-setuptools = "^70.0.0"
-
-
-[tool.poetry.group.test-flake8.dependencies]
-flake8 = "^7.0.0"
-flake8-bugbear = "^24.4.26"
-flake8-typing-imports = "^1.15.0"
-flake8-colors = "^0.1.9"
-pep8-naming = "^0.14.1"
-pydocstyle = "^6.3.0"
-
-
-[tool.poetry.group.test-black.dependencies]
-black = "^24.4.2"
-
-
-[tool.poetry.group.test-bandit.dependencies]
-bandit = "^1.7.8"
-
-
-[tool.poetry.group.test-mypy.dependencies]
-mypy = "^1.10.0"
-
-
-[tool.poetry.group.test-pypi.dependencies]
-twine = "^5.1.0"
-
-
-[tool.poetry.group.test-pip-missing-reqs.dependencies]
-pip-check-reqs = "^2.5.3"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR is to backport deepaas-cli fixes to Python 3.6, in order to allow old modules from the marketplace to be deployed with OSCAR.

I have started form the latest `2.5.2` version (branch `releases/2.x`) and done the following changes:
* removed `groups` from TOML (only used for testing purposes), because not compatible with the Poetry version available in 3.6 (`1.1.15`) ([ref](https://python-poetry.org/blog/announcing-poetry-1.2.0/#dropping-support-for-python-27-35-and-36-as-runtimes), [ref](https://stackoverflow.com/questions/73876790/poetry-configuration-is-invalid-additional-properties-are-not-allowed-group))
* downgraded `dependencies` in TOML until reaching Python 3.6-compatible versions
* commented `importlib.metadata` (not available in 3.6-compatible version of importlib)

**⚠️ Note: I haven't modified Github workflows because I understand this will be a one-time backport.**

**Tested:** This has been tested with the `ai4os-image-classification` package (Python 3.6.8), with:
* model metadata
* train
* predict
* deepaas-cli

```console
root@b81b8cb2f65f:/srv/deepaas# deepaas-cli predict --files "/srv/ai4os-image-classification-tf/data/samples/labrador.jpeg" 

[...]

1/1 [==============================] - 1s 740ms/step
{'status': 'OK', 'labels': ['golden_retriever', 'Irish_setter', 'gibbon', 'Saluki', 'Chihuahua'], 'probabilities': [0.61965012550354, 0.09341743588447571, 0.04869064316153526, 0.04133171588182449, 0.028836732730269432]}
```